### PR TITLE
Remove 'gorilla' framework

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"flag"
-	"github.com/gorilla/context"
 	"log"
 	"net"
 	"net/http"
@@ -76,8 +75,8 @@ func main() {
 
 	log.Printf("Serving on port %d out of directory: %s", config.MoneyGo.Port, config.MoneyGo.Basedir)
 	if config.MoneyGo.Fcgi {
-		fcgi.Serve(listener, context.ClearHandler(servemux))
+		fcgi.Serve(listener, servemux)
 	} else {
-		http.Serve(listener, context.ClearHandler(servemux))
+		http.Serve(listener, servemux)
 	}
 }


### PR DESCRIPTION
It was being used for session management, but we weren't using any of
the features that differentiated it from using go's cookies directly so
it is hard to justify the additional dependencies.