### PR TITLE
Add node_modules/.bin to PATH during Makefile build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 JS_SOURCES = $(wildcard js/*.js) $(wildcard js/*/*.js)
 
+export PATH := node_modules/.bin:$(PATH)
+
 all: static/bundle.js static/react-widgets static/codemirror/codemirror.css
 
 node_modules:


### PR DESCRIPTION
Fixes the need to have browserify installed globally for the build to work.